### PR TITLE
Suppress verbose readr output

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -11,4 +11,27 @@
   #set DCMI Vocabularies
   setDCMIVocabularies()
 
-} # nocov end
+  old_col_types <- getOption ("readr.show_col_types")
+  if (!is.null (old_col_types)) {
+      options (atom4R.show_col_types = old_col_types)
+  }
+  old_progress <- getOption ("readr.show_progress")
+  if (!is.null (old_progress)) {
+      options (atom4R.show_progress = old_progress)
+  }
+  options (readr.show_col_types = FALSE)
+  options (readr.show_progress = FALSE)
+}
+
+.onUnload <- function (libname, pkgname) {
+
+    if (!is.null (options (atom4R.show_col_types))) {
+        options (readr.show_col_types = options (atom4R.show_col_types))
+    }
+    if (!is.null (options (atom4R.show_progress))) {
+        options (readr.show_progress = options (atom4R.show_progress))
+    }
+    options (atom4R.show_col_types = NULL)
+    options (atom4R.show_progress = NULL)
+}
+# nocov end


### PR DESCRIPTION
@eblondel This PR is a *temporary* fix until one or both of https://github.com/ropensci/rdflib/pull/44 or https://github.com/ropensci/rdflib/issues/42 are addressed. These lines will then no longer be necessary, but having them here in the meantime still provides much-needed relief from the incessant verbosity of `readr` when creating `atom4R` objects.