### PR TITLE
List of classes

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -11,4 +11,27 @@
   #set DCMI Vocabularies
   setDCMIVocabularies()
 
-} # nocov end
+  old_col_types <- getOption ("readr.show_col_types")
+  if (!is.null (old_col_types)) {
+      options (atom4R.show_col_types = old_col_types)
+  }
+  old_progress <- getOption ("readr.show_progress")
+  if (!is.null (old_progress)) {
+      options (atom4R.show_progress = old_progress)
+  }
+  options (readr.show_col_types = FALSE)
+  options (readr.show_progress = FALSE)
+}
+
+.onUnload <- function (libname, pkgname) {
+
+    if (!is.null (options (atom4R.show_col_types))) {
+        options (readr.show_col_types = options (atom4R.show_col_types))
+    }
+    if (!is.null (options (atom4R.show_progress))) {
+        options (readr.show_progress = options (atom4R.show_progress))
+    }
+    options (atom4R.show_col_types = NULL)
+    options (atom4R.show_progress = NULL)
+}
+# nocov end

--- a/R/profile.R
+++ b/R/profile.R
@@ -11,27 +11,5 @@
   #set DCMI Vocabularies
   setDCMIVocabularies()
 
-  old_col_types <- getOption ("readr.show_col_types")
-  if (!is.null (old_col_types)) {
-      options (atom4R.show_col_types = old_col_types)
-  }
-  old_progress <- getOption ("readr.show_progress")
-  if (!is.null (old_progress)) {
-      options (atom4R.show_progress = old_progress)
-  }
-  options (readr.show_col_types = FALSE)
-  options (readr.show_progress = FALSE)
-}
-
-.onUnload <- function (libname, pkgname) {
-
-    if (!is.null (options (atom4R.show_col_types))) {
-        options (readr.show_col_types = options (atom4R.show_col_types))
-    }
-    if (!is.null (options (atom4R.show_progress))) {
-        options (readr.show_progress = options (atom4R.show_progress))
-    }
-    options (atom4R.show_col_types = NULL)
-    options (atom4R.show_progress = NULL)
 }
 # nocov end

--- a/R/profile.R
+++ b/R/profile.R
@@ -11,5 +11,4 @@
   #set DCMI Vocabularies
   setDCMIVocabularies()
 
-}
-# nocov end
+} # nocov end


### PR DESCRIPTION
@eblondel I needed to locally install this PR to get `atom4R` to work as a dependency. The only way in current form is to use a `library` call directly, because even `loadNamespace()` does not bring the objects into your `eval(parse(x))` calls. This may need some tweaking to get into a form you're happy with, but hopefully it's a good start. Disclaimer: I don't understand why you search all loaded namespaces for classes, but I'm sure you've got your reasons for that. Given that, I may have misinterpreted what this function is intended to do? Happy to iterate:smile: